### PR TITLE
feat: add dashboard layout with routing and theming

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,22 @@
     "test": "echo \"No tests configured\""
   },
   "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.3",
+    "@mui/icons-material": "^5.15.20",
+    "@mui/material": "^5.15.20",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
     "vite": "^5.0.0"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './ui/App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,50 @@
 import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { useThemeStore } from './store/useTheme';
+import Layout from './components/layout/Layout';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import Configuracion from './pages/Configuracion';
+import NotFound from './pages/NotFound';
+import PrivateRoute from './routes/PrivateRoute';
 
 const App: React.FC = () => {
-  return <h1>Hexagonal Architecture React App</h1>;
+  const mode = useThemeStore((state) => state.mode);
+  const theme = React.useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route element={<Layout />}>
+            <Route
+              path="/dashboard"
+              element={
+                <PrivateRoute>
+                  <Dashboard />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/configuracion"
+              element={
+                <PrivateRoute>
+                  <Configuracion />
+                </PrivateRoute>
+              }
+            />
+          </Route>
+          <Route path="/notFound" element={<NotFound />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/src/ui/components/layout/Body.tsx
+++ b/src/ui/components/layout/Body.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Body: React.FC<Props> = ({ children }) => (
+  <Box component="main" className="flex-1 p-4">
+    {children}
+  </Box>
+);
+
+export default Body;

--- a/src/ui/components/layout/Footer.tsx
+++ b/src/ui/components/layout/Footer.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+const Footer: React.FC = () => {
+  return (
+    <Box component="footer" className="bg-gray-100 text-center py-4">
+      <Typography variant="body2">© {new Date().getFullYear()} Intranet</Typography>
+    </Box>
+  );
+};
+
+export default Footer;

--- a/src/ui/components/layout/Header.tsx
+++ b/src/ui/components/layout/Header.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import MenuIcon from '@mui/icons-material/Menu';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import { useThemeStore } from '../../store/useTheme';
+
+interface Props {
+  onMenuClick: () => void;
+  drawerWidth: number;
+}
+
+const Header: React.FC<Props> = ({ onMenuClick, drawerWidth }) => {
+  const toggleTheme = useThemeStore((state) => state.toggle);
+  return (
+    <AppBar
+      position="static"
+      sx={{ width: { sm: `calc(100% - ${drawerWidth}px)` }, ml: { sm: `${drawerWidth}px` } }}
+    >
+      <Toolbar>
+        <IconButton
+          color="inherit"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2, display: { sm: 'none' } }}
+        >
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Intranet
+        </Typography>
+        <IconButton color="inherit" onClick={toggleTheme}>
+          <Brightness4Icon />
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/ui/components/layout/Layout.tsx
+++ b/src/ui/components/layout/Layout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Header from './Header';
+import Sidebar from './Sidebar';
+import Footer from './Footer';
+import Body from './Body';
+import { Outlet } from 'react-router-dom';
+
+const drawerWidth = 240;
+
+const Layout: React.FC = () => {
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
+
+  return (
+    <Box className="flex min-h-screen">
+      <Sidebar
+        mobileOpen={mobileOpen}
+        onDrawerToggle={handleDrawerToggle}
+        drawerWidth={drawerWidth}
+      />
+      <Box className="flex flex-1 flex-col">
+        <Header onMenuClick={handleDrawerToggle} drawerWidth={drawerWidth} />
+        <Body>
+          <Outlet />
+        </Body>
+        <Footer />
+      </Box>
+    </Box>
+  );
+};
+
+export default Layout;

--- a/src/ui/components/layout/Sidebar.tsx
+++ b/src/ui/components/layout/Sidebar.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Box from '@mui/material/Box';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  mobileOpen: boolean;
+  onDrawerToggle: () => void;
+  drawerWidth: number;
+}
+
+const Sidebar: React.FC<Props> = ({ mobileOpen, onDrawerToggle, drawerWidth }) => {
+  const drawer = (
+    <Box onClick={onDrawerToggle} sx={{ textAlign: 'center' }} className="mt-10">
+      <List>
+        <ListItem disablePadding>
+          <ListItemButton component={Link} to="/dashboard">
+            <ListItemText primary="Dashboard" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={Link} to="/configuracion">
+            <ListItemText primary="Configuración" />
+          </ListItemButton>
+        </ListItem>
+      </List>
+    </Box>
+  );
+
+  return (
+    <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}>
+      <Drawer
+        variant="temporary"
+        open={mobileOpen}
+        onClose={onDrawerToggle}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', sm: 'none' },
+          '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+        }}
+      >
+        {drawer}
+      </Drawer>
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', sm: 'block' },
+          '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+        }}
+        open
+      >
+        {drawer}
+      </Drawer>
+    </Box>
+  );
+};
+
+export default Sidebar;

--- a/src/ui/pages/Configuracion.tsx
+++ b/src/ui/pages/Configuracion.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+const Configuracion: React.FC = () => (
+  <Typography variant="h4">Configuración</Typography>
+);
+
+export default Configuracion;

--- a/src/ui/pages/Dashboard.tsx
+++ b/src/ui/pages/Dashboard.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+const Dashboard: React.FC = () => (
+  <Typography variant="h4">Dashboard</Typography>
+);
+
+export default Dashboard;

--- a/src/ui/pages/Home.tsx
+++ b/src/ui/pages/Home.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { Link } from 'react-router-dom';
+
+const Home: React.FC = () => (
+  <Box className="p-4">
+    <Typography variant="h4" gutterBottom>
+      Home Publico
+    </Typography>
+    <Button variant="contained" component={Link} to="/login">
+      Ir a Login
+    </Button>
+  </Box>
+);
+
+export default Home;

--- a/src/ui/pages/Login.tsx
+++ b/src/ui/pages/Login.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { useAuthStore } from '../store/useAuth';
+import { useNavigate } from 'react-router-dom';
+
+const Login: React.FC = () => {
+  const login = useAuthStore((state) => state.login);
+  const navigate = useNavigate();
+  const handleLogin = () => {
+    login();
+    navigate('/dashboard');
+  };
+
+  return (
+    <Box className="p-4">
+      <Typography variant="h4" gutterBottom>
+        Login
+      </Typography>
+      <Button variant="contained" onClick={handleLogin} className="mt-4">
+        Entrar
+      </Button>
+    </Box>
+  );
+};
+
+export default Login;

--- a/src/ui/pages/NotFound.tsx
+++ b/src/ui/pages/NotFound.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { Link } from 'react-router-dom';
+
+const NotFound: React.FC = () => (
+  <Box className="p-4 text-center">
+    <Typography variant="h4" gutterBottom>
+      404 - No encontrado
+    </Typography>
+    <Button variant="contained" component={Link} to="/">
+      Volver al inicio
+    </Button>
+  </Box>
+);
+
+export default NotFound;

--- a/src/ui/routes/PrivateRoute.tsx
+++ b/src/ui/routes/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../store/useAuth';
+
+interface Props {
+  children: React.ReactElement;
+}
+
+const PrivateRoute: React.FC<Props> = ({ children }) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/src/ui/store/useAuth.ts
+++ b/src/ui/store/useAuth.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isAuthenticated: false,
+  login: () => set({ isAuthenticated: true }),
+  logout: () => set({ isAuthenticated: false }),
+}));

--- a/src/ui/store/useTheme.ts
+++ b/src/ui/store/useTheme.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ThemeState {
+  mode: 'light' | 'dark';
+  toggle: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  mode: 'light',
+  toggle: () => set((state) => ({ mode: state.mode === 'light' ? 'dark' : 'light' })),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Material UI, Tailwind, React Router and Zustand dependencies
- implement responsive dashboard layout with header, sidebar, body and footer
- set up routing with public and private routes and theme toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf037cf148331a93291b852e076cf